### PR TITLE
reintroduce 'add' and 'discard' to the omnetpp namespace

### DIFF
--- a/R-package/NAMESPACE
+++ b/R-package/NAMESPACE
@@ -1,6 +1,6 @@
 useDynLib(omnetpp)
 
-export(loadDataset, loadVectors, generateIndexFiles)
+export(loadDataset, loadVectors, generateIndexFiles, add, discard)
 
 S3method(summary, omnetpp_dataset)
 S3method(print, omnetpp_dataset_summary)

--- a/R-package/R/loadDataset.R
+++ b/R-package/R/loadDataset.R
@@ -25,21 +25,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+add <- function(type=NULL, select=NULL) {
+  list(quote(add), type=type, select=select)
+}
+discard <- function(type=NULL, select=NULL) {
+  list(quote(discard), type=type, select=select)
+}
 loadDataset <- function(files, ...) {
-  evalCommands <- function(commands) {
-    add <- function(type=NULL, select=NULL) {
-      list(quote(add), type=type, select=select)
-    }
-    
-    discard <- function(type=NULL, select=NULL) {
-      list(quote(discard), type=type, select=select)
-    }
-
-    eval(commands, envir=as.list(environment()), enclos=parent.frame(2))
-  }
-
   files <- unlist(sapply(files, Sys.glob), use.names=FALSE)
-  commands <- evalCommands(substitute(list(...)))
+  commands <- list(...)
   
   dataset <- .Call('callLoadDataset', files, commands)
 

--- a/R-package/src/common/bigdecimal.cc
+++ b/R-package/src/common/bigdecimal.cc
@@ -38,7 +38,7 @@ USING_NAMESPACE
 // helpers
 static inline int64 max(int64 x, int64 y) { return x > y ? x : y; }
 static inline int64 min(int64 x, int64 y) { return x < y ? x : y; }
-static inline int64 abs(int64 x) { return x >= 0 ? x : -x; }
+static inline int64 int_abs(int64 x) { return x >= 0 ? x : -x; }
 static inline int sgn(int64 x) { return (x > 0 ? 1 : (x < 0 ? -1 : 0)); }
 
 BigDecimal BigDecimal::Zero(0, 0);
@@ -146,7 +146,7 @@ int64 BigDecimal::getDigits(int scale, int numDigits) const
     if (start >= end)
         return 0;
 
-    int64 val = abs(this->intVal);
+    int64 val = int_abs(this->intVal);
     for (int i = this->scale; i < start; ++i)
         val /= 10;
 


### PR DESCRIPTION
reintroducing 'add' and 'discard' enables the possibility to pass a
variable as the select argument of such operations, e.g.:

selector <- 'name(fieldName)'
loadDataset('file.vec', add('vector', select=selector))
