### PR TITLE
Add support for .sci itervar parameter

### DIFF
--- a/R-package/src/scave/indexfile.cc
+++ b/R-package/src/scave/indexfile.cc
@@ -186,6 +186,12 @@ bool RunData::parseLine(char **tokens, int numTokens, const char *filename, int6
         this->moduleParams[tokens[1]] = tokens[2];
         return true;
     }
+    else if (tokens[0][0] == 'i' && strcmp(tokens[0], "itervar") == 0)
+    {
+        CHECK(numTokens >= 3, "itervar <name> <value>");
+        this->moduleParams[tokens[1]] = tokens[2];
+        return true;
+    }
     else if (tokens[0][0] == 'r' && strcmp(tokens[0], "run") == 0)
     {
         CHECK(numTokens >= 2, "missing run name");


### PR DESCRIPTION
Since Omnet 5.2 version it's no more possible to import vector data generated by iterated experiments.
The error is caused by a new .sci parameter type called "itervar" that causes the following error on loadDataset() call:
`Error in callLoadDataset: missing fields from block, file [...]`

From the [Omnet 5.2 changelog](https://www.omnetpp.org/9-articles/software/3747-omnet-5-2-released)

> Save iteration variables separately from run attributes ("itervar" lines). NOTE: This changes result file format!

This code should mantain the compatibility with the older .sci file versions.