### PR TITLE
Add parenthesis around a macro parameter

### DIFF
--- a/R-package/src/scave/indexedvectorfilereader.cc
+++ b/R-package/src/scave/indexedvectorfilereader.cc
@@ -124,7 +124,7 @@ long IndexedVectorFileReaderNode::readBlock(const Block *blockPtr, const PortDat
 
     const char *file = filename.c_str();
     file_offset_t offset;
-#define CHECK(cond, msg) {if (!cond) throw opp_runtime_error(msg ", file %s, offset %"LL"d", file, (int64)offset); }
+#define CHECK(cond, msg) {if (!(cond)) throw opp_runtime_error(msg ", file %s, offset %"LL"d", file, (int64)offset); }
 
     VectorData *vector = portDataPtr->vector;
     file_offset_t startOffset = blockPtr->startOffset;

--- a/R-package/src/scave/indexedvectorfilereader2.cc
+++ b/R-package/src/scave/indexedvectorfilereader2.cc
@@ -126,7 +126,7 @@ bool IndexedVectorFileReaderNode2::readNextBlock(PortData &portData)
 
     const char *file = filename.c_str();
     file_offset_t offset;
-#define CHECK(cond, msg) {if (!cond) throw opp_runtime_error(msg ", file %s, offset %"LL"d", file, (int64)offset); }
+#define CHECK(cond, msg) {if (!(cond)) throw opp_runtime_error(msg ", file %s, offset %"LL"d", file, (int64)offset); }
 
 
     Block &block = vector->blocks[portData.currentBlockIndex++];


### PR DESCRIPTION
My compiler caught a problem caused by using a macro parameter without parenthesis.

```
scave/indexedvectorfilereader.cc:160:9: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
        CHECK(vectorId == vector->vectorId, "vector file reader: unexpected vector id");
        ^              ~~
scave/indexedvectorfilereader.cc:127:31: note: expanded from macro 'CHECK'
#define CHECK(cond, msg) {if (!cond) throw opp_runtime_error(msg ", file %s, offset %"LL"d", file, (int64)offset); }```