### PR TITLE
Make itervar-values contained in sca- and vec-files available to R

### DIFF
--- a/R-package/R/loadDataset.R
+++ b/R-package/R/loadDataset.R
@@ -50,7 +50,8 @@ loadDataset <- function(files, ...) {
       fields = as.data.frame(dataset$fields),
       bins = as.data.frame(dataset$bins),
       params = as.data.frame(dataset$params),
-      attrs = as.data.frame(dataset$attrs)
+      attrs = as.data.frame(dataset$attrs),
+      itervars = as.data.frame(dataset$itervars)
     ),
     class='omnetpp_dataset'
   )

--- a/R-package/src/scave/dataflownetworkbuilder.cc
+++ b/R-package/src/scave/dataflownetworkbuilder.cc
@@ -341,7 +341,7 @@ DataflowManager* PNetwork::createDataflowNetwork()
 
 DataflowNetworkBuilder::~DataflowNetworkBuilder()
 {
-    // TODO
+  delete dataflowManagerPtr;
 }
 
 void DataflowNetworkBuilder::build(const IDList &input, const ProcessingOperationList &operations)

--- a/R-package/src/scave/indexedvectorfilereader.cc
+++ b/R-package/src/scave/indexedvectorfilereader.cc
@@ -90,8 +90,6 @@ void IndexedVectorFileReaderNode::readIndexFile()
 
     if (!IndexFile::isVectorFile(fn))
         throw opp_runtime_error("indexed vector file reader: not a vector file, file %s", fn);
-    if (!IndexFile::isIndexFileUpToDate(fn))
-        throw opp_runtime_error("indexed vector file reader: index file is not up to date, file %s", fn);
 
     string indexFileName = IndexFile::getIndexFileName(fn);
     IndexFileReader reader(indexFileName.c_str());

--- a/R-package/src/scave/indexfile.cc
+++ b/R-package/src/scave/indexfile.cc
@@ -423,6 +423,9 @@ void IndexFileReader::parseLine(char **tokens, int numTokens, VectorFileIndex *i
         CHECK(parseInt(tokens[1], version), "version is not a number", lineNum);
         CHECK(version <= 2, "expects version 2 or lower", lineNum);
     }
+    else if (tokens[0][0] == 'i' && strcmp(tokens[0], "itervar") == 0) {
+        return;
+    }
     else if (index->run.parseLine(tokens, numTokens, filename.c_str(), lineNum))
     {
         return;

--- a/R-package/src/scave/resultfilemanager.cc
+++ b/R-package/src/scave/resultfilemanager.cc
@@ -1082,6 +1082,19 @@ void ResultFileManager::processLine(char **vec, int numTokens, sParseContext &ct
         HistogramResult &histogram = ctx.fileRef->histogramResults.back();
         histogram.addBin(lower_bound, value);
     }
+    else if (vec[0][0]=='i' && !strcmp(vec[0],"itervar")) {
+
+        CHECK(numTokens>=3, "invalid result file: 'itervar <name> <value>' expected");
+
+        std::string varName = vec[1];
+        std::string varValue = vec[2];
+
+        StringMap &itervars = ctx.fileRunRef->runRef->itervars;
+        StringMap::iterator oldRef = itervars.find(varName);
+        CHECK(oldRef == itervars.end() || oldRef->second == varValue,
+           "Value of iteration variable conflicts with previously loaded value");
+        itervars[varName] = varValue;
+    }
     else if (vec[0][0]=='a' && !strcmp(vec[0],"attr"))
     {
         CHECK(numTokens>=3, "invalid result file: 'attr <name> <value>' expected");

--- a/R-package/src/scave/resultfilemanager.h
+++ b/R-package/src/scave/resultfilemanager.h
@@ -208,6 +208,9 @@ struct SCAVE_API Run
     StringMap attributes;
     int runNumber; // this is stored separately as well, for convenience
 
+    // iteration variables, denotes by "itervar"
+    StringMap itervars;
+
     // module parameters: maps wildcard pattern to value
     StringMap moduleParams;
 
@@ -217,6 +220,12 @@ struct SCAVE_API Run
         StringMap::const_iterator it = attributes.find(attrName);
         return it==attributes.end() ? NULL : it->second.c_str();
     }
+
+    const char *getIterationVariable(const char *varName) const {
+        StringMap::const_iterator it = itervars.find(varName);
+        return it==itervars.end() ? NULL : it->second.c_str();
+    }
+
     const char *getModuleParam(const char *paramName) const {
         StringMap::const_iterator it = moduleParams.find(paramName);
         return it==moduleParams.end() ? NULL : it->second.c_str();


### PR DESCRIPTION
Hi,

the commit in this pull request extends the `loadDataset` function such that the returned dataframe also includes the "itervar"-entries from the scalar/vector files, making it easier to group different runs by simulation parameter values.

The code added to the `processLine`-method of the `ResultFileManager`-class is similar to the code regarding processing of run attributes. One rather subtle change is that I replaced the line `PROTECT(dataset = NEW_LIST(9))` at the beginning of the `exportDataset`-method in loadDataset.cc with `PROTECT(dataset = NEW_LIST(datasetColumnsLength))`, as to me it seems that the "9" was just a hard-coded version of the number of dataset columns.

I am also not familiar with writing R extensions and I am not sure if the call to `UNPROTECT(1)` is at the right place or if it should occur just after all the itervar entries have been added to the dataframe. 

Kind regards,
Martin